### PR TITLE
Add `std` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@
 ## General
 This repo is intended to function as a catch-all bucket for datastructures that I am working with for side projects and learning purposes.
 
-### Note
-All collections must function without a need for stdlib by default.
-
 ## Usage
 ### Testing
 Tests and documentation are provided primarily via docstring examples primarily but a few tests are additionally provided through standard rust unit testing and can be run via:

--- a/README.md
+++ b/README.md
@@ -5,15 +5,20 @@
 - [collections-ext](#collections-ext)
 	- [Table of Contents](#table-of-contents)
 	- [General](#general)
+		- [Note](#note)
 	- [Usage](#usage)
 		- [Testing](#testing)
 			- [Benchmark tests](#benchmark-tests)
+		- [Features](#features)
 	- [Warnings](#warnings)
 
 <!-- /TOC -->
 
 ## General
 This repo is intended to function as a catch-all bucket for datastructures that I am working with for side projects and learning purposes.
+
+### Note
+All collections must function without a need for stdlib by default.
 
 ## Usage
 ### Testing
@@ -29,6 +34,10 @@ Additionally benchmark tests are provided via `criterion` and can be run via:
 ```
 cargo bench
 ```
+
+### Features
+
+- `std`: Enable the standard library. Disabled by default for core.
 
 ## Warnings
 Please nobody use this. This is entirely an experiment to support insane restrictions I've imposed on myself to build a computer from first principles.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 - [collections-ext](#collections-ext)
 	- [Table of Contents](#table-of-contents)
 	- [General](#general)
-		- [Note](#note)
 	- [Usage](#usage)
 		- [Testing](#testing)
 			- [Benchmark tests](#benchmark-tests)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,6 @@
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
 pub mod tree;


### PR DESCRIPTION
# Introduction
This PR disables the `std` library by default. Preferring to make all collections `no_std` compatible.

# Linked Issues
#21 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment
