### PR TITLE
Implement a find method with predicate on trees

### DIFF
--- a/src/tree/binary/mod.rs
+++ b/src/tree/binary/mod.rs
@@ -106,6 +106,13 @@ where
         }
     }
 
+    pub fn find<P>(&self, predicate: P) -> Option<&T>
+    where
+        P: FnMut(&&T) -> bool,
+    {
+        self.traverse_in_order().find(predicate)
+    }
+
     /// Inserts a value `T` into the tree returning a the modified tree in
     /// place.
     pub fn insert(mut self, value: T) -> Self {
@@ -500,5 +507,12 @@ mod tests {
         // skip 511 and 512
         let expected: Vec<u16> = (0..511).chain(513..1024).collect();
         assert_eq!(expected, received);
+    }
+
+    #[test]
+    fn should_find_node_by_predicate() {
+        let tree = (0..1024).fold(BinaryTree::default(), |tree, x| tree.insert(x));
+
+        assert!(tree.find(|x| x == &&513).is_some());
     }
 }

--- a/src/tree/binary/mod.rs
+++ b/src/tree/binary/mod.rs
@@ -105,7 +105,16 @@ where
             SearchResult::Empty
         }
     }
-
+    /// Searches for a node in the tree that satisfies the given predicate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use collections_ext::tree::binary::BinaryTree;
+    ///
+    /// let tree = (0..1024).fold(BinaryTree::default(), |tree, x| tree.insert(x));
+    /// assert!(tree.find(|x| x == &&513).is_some());
+    /// ```
     pub fn find<P>(&self, predicate: P) -> Option<&T>
     where
         P: FnMut(&&T) -> bool,
@@ -507,12 +516,5 @@ mod tests {
         // skip 511 and 512
         let expected: Vec<u16> = (0..511).chain(513..1024).collect();
         assert_eq!(expected, received);
-    }
-
-    #[test]
-    fn should_find_node_by_predicate() {
-        let tree = (0..1024).fold(BinaryTree::default(), |tree, x| tree.insert(x));
-
-        assert!(tree.find(|x| x == &&513).is_some());
     }
 }

--- a/src/tree/redblack/mod.rs
+++ b/src/tree/redblack/mod.rs
@@ -212,6 +212,16 @@ where
         }
     }
 
+    /// Searches for a node in the tree that satisfies the given predicate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use collections_ext::tree::redblack::RedBlackTree;
+    ///
+    /// let tree = (0..1024).fold(RedBlackTree::default(), |tree, x| tree.insert(x));
+    /// assert!(tree.find(|x| x == &&513).is_some());
+    /// ```
     pub fn find<P>(&self, predicate: P) -> Option<&T>
     where
         P: FnMut(&&T) -> bool,
@@ -1070,12 +1080,5 @@ mod tests {
         // skip 511 and 512
         let expected: Vec<u16> = (0..511).chain(513..1024).collect();
         assert_eq!(expected, received);
-    }
-
-    #[test]
-    fn should_find_node_by_predicate() {
-        let tree = (0..1024).fold(RedBlackTree::default(), |tree, x| tree.insert(x));
-
-        assert!(tree.find(|x| x == &&513).is_some());
     }
 }

--- a/src/tree/redblack/mod.rs
+++ b/src/tree/redblack/mod.rs
@@ -212,6 +212,13 @@ where
         }
     }
 
+    pub fn find<P>(&self, predicate: P) -> Option<&T>
+    where
+        P: FnMut(&&T) -> bool,
+    {
+        self.traverse_in_order().find(predicate)
+    }
+
     pub fn insert(mut self, value: T) -> Self {
         self.insert_mut(value);
         self

--- a/src/tree/redblack/mod.rs
+++ b/src/tree/redblack/mod.rs
@@ -1071,4 +1071,11 @@ mod tests {
         let expected: Vec<u16> = (0..511).chain(513..1024).collect();
         assert_eq!(expected, received);
     }
+
+    #[test]
+    fn should_find_node_by_predicate() {
+        let tree = (0..1024).fold(RedBlackTree::default(), |tree, x| tree.insert(x));
+
+        assert!(tree.find(|x| x == &&513).is_some());
+    }
 }


### PR DESCRIPTION
# Introduction
This PR implements a find method on the trees for traversing with a predicate. Effectively this wraps an in-order traversal iteration's find.
# Linked Issues
resolves #31 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
