### PR TITLE
zero elems value on set clear

### DIFF
--- a/src/set/sparse.rs
+++ b/src/set/sparse.rs
@@ -127,7 +127,8 @@ impl SparseSet {
 
     /// Clears the set, removing all values.
     pub fn clear(&mut self) {
-        self.dense.clear()
+        self.elems = 0;
+        self.dense.clear();
     }
 
     fn resize(&mut self, new_len: usize) {


### PR DESCRIPTION
# Introduction
Small bugfix to 0 out elems field when the sparse set is cleared.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
